### PR TITLE
deleted identity widget and switched to github backend

### DIFF
--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -1,5 +1,5 @@
 backend:
-  name: git-gateway
+  name: github
   branch: main # Branch to update (optional; defaults to master)
   repo: climate-tech-handbook/climate-tech-handbook
 

--- a/docs/admin/index.html
+++ b/docs/admin/index.html
@@ -3,9 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="robots" content="noindex" />
   <title>Content Manager</title>
-  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
   <!-- Include the script that builds the page and powers Decap CMS -->


### PR DESCRIPTION
switching from git-gateway backend to github to attach authors to their editorial commits and PRs in github.