### PR TITLE
Fixes #219:  Make sidebar display on all pages in the /docs folder

### DIFF
--- a/custom-plugins/auto-set-displayed-sidebar.js
+++ b/custom-plugins/auto-set-displayed-sidebar.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const { parse } = require('yaml');
+
+const readdirAsync = promisify(fs.readdir);
+const readFileAsync = promisify(fs.readFile);
+const writeFileAsync = promisify(fs.writeFile);
+
+async function autoSetDisplayedSidebar() {
+  const docsFolderPath = path.resolve(__dirname, '../docs');
+
+  const files = await readdirAsync(docsFolderPath);
+  
+  for (const file of files) {
+      if(file === 'breadcrumb-test') continue;
+      const filePath = path.resolve(docsFolderPath, file);
+      const fileContents = await readFileAsync(filePath, 'utf-8');
+
+      const frontmatterStart = fileContents.indexOf('---') + 3;
+      const frontmatterEnd = fileContents.indexOf('---', frontmatterStart);
+
+    if (frontmatterStart !== -1 && frontmatterEnd !== -1) {
+      const frontmatterContent = fileContents.slice(frontmatterStart, frontmatterEnd);
+      const frontmatter = parse(frontmatterContent);
+
+      if (!frontmatter.displayed_sidebar) {
+        frontmatter.displayed_sidebar = 'docSidebar';
+        const newFrontmatterContent = `\n${Object.entries(frontmatter).map(([key, value]) => `${key}: ${isArray(value) ? '\n - '+ value.join('\n - '):value}`).join('\n')}\n`;
+        const newFileContents = fileContents.slice(0, frontmatterStart) + newFrontmatterContent + fileContents.slice(frontmatterEnd);
+        await writeFileAsync(filePath, newFileContents, 'utf-8');
+      }
+    }
+  }
+}
+
+function isArray(ob){
+    var arrayConstructor = [].constructor;
+    return ob.constructor === arrayConstructor;
+}
+module.exports = function (context) {
+  return {
+    name: 'auto-set-displayed-sidebar',
+    async loadContent() {
+      await autoSetDisplayedSidebar();
+      return null;
+    },
+  };
+};

--- a/custom-plugins/auto-set-displayed-sidebar.js
+++ b/custom-plugins/auto-set-displayed-sidebar.js
@@ -24,6 +24,10 @@ async function autoSetDisplayedSidebar() {
       const frontmatterContent = fileContents.slice(frontmatterStart, frontmatterEnd);
       const frontmatter = parse(frontmatterContent);
 
+      if(frontmatter.displayed_sidebar === null){
+        continue;
+      }
+
       if (!frontmatter.displayed_sidebar) {
         frontmatter.displayed_sidebar = 'docSidebar';
         const newFrontmatterContent = `\n${Object.entries(frontmatter).map(([key, value]) => `${key}: ${isArray(value) ? '\n - '+ value.join('\n - '):value}`).join('\n')}\n`;

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,3 +1,7 @@
+---
+title: Contibuting.md
+---
+
 # Contribute
 
 This is your resource!

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contibuting.md
+displayed_sidebar: docSidebar
 ---
 
 # Contribute

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -1,10 +1,11 @@
 ---
 date: 2023-01-31
-tags:
-  - launch
-  - software
-authors:
-  - alexmayberry
+tags: 
+ - launch
+ - software
+authors: 
+ - alexmayberry
+displayed_sidebar: docSidebar
 ---
 
 # Hello (Climate Tech Blogging) world!

--- a/docs/how-to-use-the-handbook.md
+++ b/docs/how-to-use-the-handbook.md
@@ -1,5 +1,6 @@
 ---
 title: How to use the Handbook
+displayed_sidebar: docSidebar
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/park.md
+++ b/docs/park.md
@@ -1,5 +1,6 @@
 ---
 visibility: hidden
+displayed_sidebar: docSidebar
 ---
 
 # Parking Lot

--- a/docs/seattle-climate-lightning-talks.md
+++ b/docs/seattle-climate-lightning-talks.md
@@ -1,6 +1,7 @@
 ---
 title: Climate Lightning Talks
 hide_table_of_contents: false
+displayed_sidebar: docSidebar
 ---
 
 # Seattle Climate Lightning Talks

--- a/docs/technologies.md
+++ b/docs/technologies.md
@@ -1,5 +1,6 @@
 ---
 title: Technologies
+displayed_sidebar: docSidebar
 ---
 
 # Technologies

--- a/docs/technologies.md
+++ b/docs/technologies.md
@@ -1,3 +1,7 @@
+---
+title: Technologies
+---
+
 # Technologies
 
 457 total, from the UN Climate Technology Centre & Network [^unctc-n]

--- a/docs/what-is-climate-tech.md
+++ b/docs/what-is-climate-tech.md
@@ -1,5 +1,6 @@
 ---
 order: 900
+displayed_sidebar: docSidebar
 ---
 
 # What is "climate tech"?

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,6 +18,7 @@ const darkCodeTheme = themes.dracula;
     plugins: [
       require.resolve('docusaurus-lunr-search'),
       require.resolve('docusaurus-plugin-image-zoom'),
+      './custom-plugins/auto-set-displayed-sidebar.js',      
     ],
 
     presets: [

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -71,7 +71,7 @@ export default function Home(): JSX.Element {
             <h1>OUR MISSION</h1>
             <p>Our mission is to build the world's most <span>accessible</span>, 
             yet <span>comprehensive</span>, resource for anyone using technology 
-            to address our climate emergency. Your skills are the missing piece 
+            to address our climate emergency. Your skills are the missing pieces 
             in the fight against climate change. We help you join the solution 
             and make a lasting impact.</p>
             <Link className={styles.secondaryButton} to="/about">


### PR DESCRIPTION
# Pull Request for #219: Added auto-set-displayed-sidebar script

## Description:
Previously, only `.md` files with the `displayed_sidebar` attribute were rendered with a sidebar. However, manually adding this attribute to each `.md` file was impractical. To address this issue, a custom plugin named "auto-set-displayed-sidebar" has been developed. This plugin automatically adds the `displayed_sidebar` attribute to `.md` files where it is missing.

## Changes Made:
- Created a custom plugin folder and added the script `auto-set-displayed-sidebar.js`.
- Configured the custom plugin in the `docusaurus.config.js` file.
- Executed the script to add the missing `displayed_sidebar` property and committed the updated `.md` files.

## Related Issues:
This pull request resolves issue #219.

### Before Fix:
![Before Fix](https://github.com/climate-tech-handbook/climate-tech-handbook/assets/115802873/6e0cd000-8faf-44ba-8592-2962f47352a5)

### After Fix:
![After Fix](https://github.com/climate-tech-handbook/climate-tech-handbook/assets/115802873/e88f7443-3fb6-4541-aaf5-921b2e3be58c)

---
This pull request addresses the need for a more automated approach to ensure consistency in rendering `.md` files with the sidebar. Your feedback and suggestions for further improvements are welcome. Thank you!