### PR TITLE
Fixed bug,   Warning error on Startup.

### DIFF
--- a/src/theme/DocSidebarItem/Category/index.js
+++ b/src/theme/DocSidebarItem/Category/index.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useMemo} from 'react';
 import clsx from 'clsx';
 import { ThemeClassNames, useThemeConfig, usePrevious, Collapsible, useCollapsible } from '@docusaurus/theme-common';
-import { isActiveSidebarItem, findFirstCategoryLink, useDocSidebarItemsExpandedState, isSamePath } from '@docusaurus/theme-common/internal';
+import { isActiveSidebarItem,  useDocSidebarItemsExpandedState, isSamePath } from '@docusaurus/theme-common/internal';
 import Link from '@docusaurus/Link';
 import {translate} from '@docusaurus/Translate';
 import useIsBrowser from '@docusaurus/useIsBrowser';


### PR DESCRIPTION
Removed  from imports in  src/theme/Category/index.js        {findFirstCategory} @docusaurus/theme-common/internal-, it is tying to find something that does not exist.  has become depreciated and it is not there. Not part of Docusaurus- Researched on git hub issues- probably depreciated on the last update to v3 , they were working on it then. Part of a function that has been worked around.   