### PR TITLE
 Firefox was not displaying the clock css correctly on the delay time…

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "compat-api/css": [
+      "default",
+      {
+        "ignore": [
+          "block-size: fit-content"
+        ]
+      }
+    ]
+  }
+}

--- a/src/components/NewClimateClock/NewClimateClock.module.css
+++ b/src/components/NewClimateClock/NewClimateClock.module.css
@@ -17,16 +17,14 @@
   text-align: center;
 }
 .clock {
-  animation: openClock 2.5s;
+  animation: openClock 3s;
 }
-
 @keyframes openClock {
   0% {
-    display: none;
-  }
-
-  100% {
-    display: none;
+      visibility: hidden;
+    }
+    100% {
+      visibility: hidden;
   }
 }
 
@@ -98,7 +96,10 @@
   }
 
   .clockMain {
-    block-size: fit-content;  
+   
+    block-size: -moz-fit-content; /* Add support for Firefox 41+ */
+    block-size: -webkit-fill-available; /* Add support for Samsung Internet 5.0+ */
+    block-size: fit-content;
     overflow: auto;
   }
 

--- a/src/components/NewClimateClock/NewClimateClock.module.css
+++ b/src/components/NewClimateClock/NewClimateClock.module.css
@@ -17,7 +17,7 @@
   text-align: center;
 }
 .clock {
-  animation: openClock 3s;
+  animation: openClock 2.5s;
 }
 @keyframes openClock {
   0% {


### PR DESCRIPTION
## The Delay was not working on firefox properly. 
 
### Lines 18-25 on NewClimateClock.css 
 * I change words  "display"  to "visibility"  so that FireFox could read it .

  * I also changed the delay from 2.5 seconds to 3 seconds. 

  ### Also on .clockMain lines 98-100 
  * I add support  firefox and Samsung as well







