### PR TITLE
#492 Table of Contents - Simple repair,  

### DIFF
--- a/docs/event-guide.md
+++ b/docs/event-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Climate Event Organizing Guide
 displayed_sidebar: docSidebar
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-buildings.md
+++ b/docs/sector-buildings.md
@@ -1,7 +1,7 @@
 ---
 title: Buildings
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-climate-adaptation.md
+++ b/docs/sector-climate-adaptation.md
@@ -1,7 +1,7 @@
 ---
 title: Climate Adaptation
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-coastal-and-ocean-sinks.md
+++ b/docs/sector-coastal-and-ocean-sinks.md
@@ -1,7 +1,7 @@
 ---
 title: Coastal and Ocean Sinks
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-data-and-accountability.md
+++ b/docs/sector-data-and-accountability.md
@@ -1,7 +1,7 @@
 ---
 title: Data and Accountability
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
 ## Sector Overview

--- a/docs/sector-engineered-sinks.md
+++ b/docs/sector-engineered-sinks.md
@@ -1,7 +1,7 @@
 ---
 title: Engineered Sinks
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-financing.md
+++ b/docs/sector-financing.md
@@ -1,7 +1,7 @@
 ---
 title: Financing
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
 ## Sector Overview

--- a/docs/sector-food-agriculture-and-land-use.md
+++ b/docs/sector-food-agriculture-and-land-use.md
@@ -1,7 +1,7 @@
 ---
 title: Food, Agriculture and Land Use
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-health-and-education.md
+++ b/docs/sector-health-and-education.md
@@ -1,7 +1,7 @@
 ---
 title: Health and Education
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
 ## Sector Overview

--- a/docs/sector-industry.md
+++ b/docs/sector-industry.md
@@ -1,7 +1,7 @@
 ---
 title: Industry
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-land-sinks.md
+++ b/docs/sector-land-sinks.md
@@ -1,7 +1,7 @@
 ---
 title: Land Sinks
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/sector-media-and-journalism.md
+++ b/docs/sector-media-and-journalism.md
@@ -1,7 +1,7 @@
 ---
 title: Media and Journalism
 displayed_sidebar: docSidebar
-# hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
 ## Sector Overview

--- a/docs/sector-transportation.md
+++ b/docs/sector-transportation.md
@@ -4,7 +4,7 @@ displayed_sidebar: docSidebar
 Tags:
   - Sector
   - Transportation
-# hide_table_of_contents: true
+  - hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 

--- a/docs/solutions.md
+++ b/docs/solutions.md
@@ -1,7 +1,7 @@
 ---
 title: Climate Solutions
 displayed_sidebar: docSidebar
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 import ImageCard from '../src/components/ImageCard/ImageCard';
 


### PR DESCRIPTION

I removed the hidden hashtag on several pages that was probably confusing people, and changed the hidden true value to hidden-false, I figure people were removing the # that was hiding the statement.  So, I just corrected them on all the pages where they were. I could have just deleted them, but this is what we did so that it is there, and it's understood.
  
added 
hide_table_of_contents: false

### Remember to use triple-### or double-## to active the TOC not single-# 👋
