### PR TITLE
 removed title config.  

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,7 +54,7 @@ export default function Home(): JSX.Element {
   return (
     <div  className={clsx(styles.bodyWrapper)}> 
     <Layout
-      title={`${siteConfig.title}`}
+      
       description="Get up to speed on climate tech as quickly as possible"
     > 
       <HomepageHeader />


### PR DESCRIPTION
# The title is already configured in the index.
* Tested on Facebook and the double title is not there anymore. 